### PR TITLE
Remove white space

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,7 @@
 require 'scraperwiki'
 require 'mechanize'
 
+<<<<<<< HEAD
 agent = Mechanize.new
 
 def scrape_page(page, url)
@@ -23,6 +24,24 @@ def scrape_page(page, url)
     }
     
     # Check if record already exists
+=======
+# Scraping from Masterview 2.0
+
+def scrape_page(page, info_url_base, comment_url)
+  page.at("table.rgMasterTable").search("tr.rgRow,tr.rgAltRow").each do |tr|
+    tds = tr.search('td').map{|t| t.inner_html.gsub("\r\n", "").strip}
+    day, month, year = tds[2].split("/").map{|s| s.to_i}
+    record = {
+      "info_url" => (page.uri + tr.search('td').at('a')["href"]).to_s,
+      "council_reference" => tds[1],
+      "date_received" => Date.new(year, month, day).to_s,
+      "description" => tds[3].gsub("&amp;", "&").split("<br>")[1].squeeze(" ").strip,
+      "address" => tds[3].gsub("&amp;", "&").split("<br>")[0].squeeze(" ").strip + ", NSW",
+      "date_scraped" => Date.today.to_s,
+      "comment_url" => comment_url
+    }
+    # p record
+>>>>>>> 6ec0a0695c23cc740cf46dee674383516c83da72
     if (ScraperWiki.select("* from data where `council_reference`='#{record['council_reference']}'").empty? rescue true)
       ScraperWiki.save_sqlite(['council_reference'], record)
     else
@@ -31,6 +50,7 @@ def scrape_page(page, url)
   end
 end
 
+<<<<<<< HEAD
 
 url = "http://www.casey.vic.gov.au/building-planning/planning-documents-on-exhibition/Advertised-planning-applications/A-C"
 page = agent.get(url)
@@ -46,3 +66,54 @@ url = "http://www.casey.vic.gov.au/building-planning/planning-documents-on-exhib
 page = agent.get(url)
 puts "Scraping page L-Z..."
 scrape_page(page, url)
+=======
+# Implement a click on a link that understands stupid asp.net doPostBack
+def click(page, doc)
+  href = doc["href"]
+  if href =~ /javascript:__doPostBack\(\'(.*)\',\'(.*)'\)/
+    event_target = $1
+    event_argument = $2
+    form = page.form_with(id: "aspnetForm")
+    form["__EVENTTARGET"] = event_target
+    form["__EVENTARGUMENT"] = event_argument
+    form.submit
+  else
+    # TODO Just follow the link likes it's a normal link
+    raise
+  end
+end
+
+url_base = "http://infomaster.griffith.nsw.gov.au/DATrackingUI/modules/applicationmaster/default.aspx"
+info_url_base = url_base + "?page=wrapper&key="
+url = url_base + "?page=found&1=thismonth&4a=10&6=F"
+comment_url = "mailto:council@griffith.nsw.gov.au"
+
+agent = Mechanize.new
+
+# Read in a page
+page = agent.get(url)
+
+form = page.forms.first
+button = form.button_with(value: "Agree")
+form.submit(button)
+# It doesn't even redirect to the correct place. Ugh
+page = agent.get(url)
+current_page_no = 1
+next_page_link = true
+
+while next_page_link
+  puts "Scraping page #{current_page_no}..."
+  scrape_page(page, info_url_base, comment_url)
+
+  page_links = page.at(".rgNumPart")
+  if page_links
+    next_page_link = page_links.search("a").find{|a| a.inner_text == (current_page_no + 1).to_s}
+  else
+    next_page_link = nil
+  end
+  if next_page_link
+    current_page_no += 1
+    page = click(page, next_page_link)
+  end
+end
+>>>>>>> 6ec0a0695c23cc740cf46dee674383516c83da72

--- a/scraper.rb
+++ b/scraper.rb
@@ -31,7 +31,6 @@ def scrape_page(page, url)
     # Check if record already exists
     if (ScraperWiki.select("* from data where `council_reference`='#{record['council_reference']}'").empty? rescue true)
       ScraperWiki.save_sqlite(['council_reference'], record)
-      puts record
     else
       puts "Skipping already saved record " + record['council_reference']
     end

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,8 +16,6 @@ def scrape_page(page, url)
     council_reference = tr.at("td a").inner_text.split("(")[0]
     council_reference_stripped = council_reference.gsub(/\A[[:space:]]+|[[:space:]]+\z/, '')
 
-    puts council_reference
-    puts council_reference_stripped
     record = {
       "info_url" => url,
       "comment_url" => url,

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,7 +1,6 @@
 require 'scraperwiki'
 require 'mechanize'
 
-<<<<<<< HEAD
 agent = Mechanize.new
 
 def scrape_page(page, url)
@@ -13,10 +12,16 @@ def scrape_page(page, url)
     # Occasionally we get a leading nbsp character (ascii 160)
     day = day.gsub(/[[:space:]]/, '')
 
+    #Will remove all whitespace and unicode variants
+    council_reference = tr.at("td a").inner_text.split("(")[0]
+    council_reference_stripped = council_reference.gsub(/\A[[:space:]]+|[[:space:]]+\z/, '')
+
+    puts council_reference
+    puts council_reference_stripped
     record = {
       "info_url" => url,
       "comment_url" => url,
-      "council_reference" => tr.at("td a").inner_text.split("(")[0],
+      "council_reference" => council_reference_stripped,
       "on_notice_to" => Date.new(year.to_i, month_i, day.to_i).to_s,
       "address" => tr.search("td")[1].inner_text + ", VIC",
       "description" => tr.search("td")[2].inner_text,
@@ -24,33 +29,15 @@ def scrape_page(page, url)
     }
     
     # Check if record already exists
-=======
-# Scraping from Masterview 2.0
-
-def scrape_page(page, info_url_base, comment_url)
-  page.at("table.rgMasterTable").search("tr.rgRow,tr.rgAltRow").each do |tr|
-    tds = tr.search('td').map{|t| t.inner_html.gsub("\r\n", "").strip}
-    day, month, year = tds[2].split("/").map{|s| s.to_i}
-    record = {
-      "info_url" => (page.uri + tr.search('td').at('a')["href"]).to_s,
-      "council_reference" => tds[1],
-      "date_received" => Date.new(year, month, day).to_s,
-      "description" => tds[3].gsub("&amp;", "&").split("<br>")[1].squeeze(" ").strip,
-      "address" => tds[3].gsub("&amp;", "&").split("<br>")[0].squeeze(" ").strip + ", NSW",
-      "date_scraped" => Date.today.to_s,
-      "comment_url" => comment_url
-    }
-    # p record
->>>>>>> 6ec0a0695c23cc740cf46dee674383516c83da72
     if (ScraperWiki.select("* from data where `council_reference`='#{record['council_reference']}'").empty? rescue true)
       ScraperWiki.save_sqlite(['council_reference'], record)
+      puts record
     else
       puts "Skipping already saved record " + record['council_reference']
     end
   end
 end
 
-<<<<<<< HEAD
 
 url = "http://www.casey.vic.gov.au/building-planning/planning-documents-on-exhibition/Advertised-planning-applications/A-C"
 page = agent.get(url)
@@ -66,54 +53,3 @@ url = "http://www.casey.vic.gov.au/building-planning/planning-documents-on-exhib
 page = agent.get(url)
 puts "Scraping page L-Z..."
 scrape_page(page, url)
-=======
-# Implement a click on a link that understands stupid asp.net doPostBack
-def click(page, doc)
-  href = doc["href"]
-  if href =~ /javascript:__doPostBack\(\'(.*)\',\'(.*)'\)/
-    event_target = $1
-    event_argument = $2
-    form = page.form_with(id: "aspnetForm")
-    form["__EVENTTARGET"] = event_target
-    form["__EVENTARGUMENT"] = event_argument
-    form.submit
-  else
-    # TODO Just follow the link likes it's a normal link
-    raise
-  end
-end
-
-url_base = "http://infomaster.griffith.nsw.gov.au/DATrackingUI/modules/applicationmaster/default.aspx"
-info_url_base = url_base + "?page=wrapper&key="
-url = url_base + "?page=found&1=thismonth&4a=10&6=F"
-comment_url = "mailto:council@griffith.nsw.gov.au"
-
-agent = Mechanize.new
-
-# Read in a page
-page = agent.get(url)
-
-form = page.forms.first
-button = form.button_with(value: "Agree")
-form.submit(button)
-# It doesn't even redirect to the correct place. Ugh
-page = agent.get(url)
-current_page_no = 1
-next_page_link = true
-
-while next_page_link
-  puts "Scraping page #{current_page_no}..."
-  scrape_page(page, info_url_base, comment_url)
-
-  page_links = page.at(".rgNumPart")
-  if page_links
-    next_page_link = page_links.search("a").find{|a| a.inner_text == (current_page_no + 1).to_s}
-  else
-    next_page_link = nil
-  end
-  if next_page_link
-    current_page_no += 1
-    page = click(page, next_page_link)
-  end
-end
->>>>>>> 6ec0a0695c23cc740cf46dee674383516c83da72


### PR DESCRIPTION
This should solve the issue that @henare raised on [this issue](https://github.com/planningalerts-scrapers/casey/issues/2).

This removes white space from the council_reference column
